### PR TITLE
The code with .ConfigureRouteHandlerJsonOptions does not compile

### DIFF
--- a/Chapter07/A_BasicModelBinding/BasicModelBinding/Program.cs
+++ b/Chapter07/A_BasicModelBinding/BasicModelBinding/Program.cs
@@ -1,14 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Optional customization of serialization
 // Make sure to update your JSON posts if you change the naming policy
-//builder.Services.ConfigureRouteHandlerJsonOptions(o => {
+//builder.Services.ConfigureHttpJsonOptions(o =>
+//{
 //    o.SerializerOptions.AllowTrailingCommas = true;
 //    o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 //    o.SerializerOptions.PropertyNameCaseInsensitive = true;
+//});
+//OR
+//builder.Services.Configure<JsonOptions>(o =>
+//{
+//    o.JsonSerializerOptions.AllowTrailingCommas = true;
+//    o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+//    o.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
 //});
 
 var app = builder.Build();


### PR DESCRIPTION
The given code with builder.Services.ConfigureRouteHandlerJsonOptions does not compile. We should use builder.Services.ConfigureHttpJsonOptions instead, or builder.Services.Configure<JsonOptions>. I implemented these two alternative approaches to successfully configure JSON serialization settings in the DI container of our application. 